### PR TITLE
Renamed dcd_uninit to dcd_deinit in dcdc_ensemble.c

### DIFF
--- a/src/portable/alif/alif_e7_dk/dcd_ensemble.c
+++ b/src/portable/alif/alif_e7_dk/dcd_ensemble.c
@@ -756,11 +756,13 @@ void dcd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr) {
     _dcd_cmd_wait(ep, CMDTYP_DEPCSTALL, 0);
 }
 
-void dcd_uninit(void) {
+bool dcd_deinit(uint8_t rhport) {
+    (void) rhport;
     usb_ctrl2_phy_power_on_reset_set();
     enable_usb_phy_isolation(); // enable usb phy isolation
     disable_usb_phy_power(); // power down usb phy
     disable_usb_periph_clk(); // disable usb peripheral clock
+    return true;
 }
 
 static uint8_t _dcd_cmd_wait(uint8_t ep, uint8_t typ, uint16_t param) {


### PR DESCRIPTION
Renamed dcd_uninit to dcd_deinit in dcdc_ensemble.c so it overwrites the weak function in usbd.c and will be called when user de-initializes the usb device via tud_deinit call.