### PR TITLE
DFP2.1.0 & Appkit-E8 support

### DIFF
--- a/hw/bsp/alif/boards/alif_e1c_dk/RTE_Components.h
+++ b/hw/bsp/alif/boards/alif_e1c_dk/RTE_Components.h
@@ -1,0 +1,18 @@
+#ifndef RTE_COMPONENTS_H
+#define RTE_COMPONENTS_H
+
+
+/*
+ * Define the Device Header File:
+ */
+#define CMSIS_device_header "alif.h"
+
+/* AlifSemiconductor::CMSIS Driver:USART@2.1.0 */
+#define RTE_Drivers_USART               /* Driver UART  */
+/* AlifSemiconductor::Device:SOC Peripherals:GPIO@2.1.0 */
+#define RTE_Drivers_IO              /* Driver GPIO */
+/* AlifSemiconductor::Device:SOC Peripherals:PINCONF@2.1.0 */
+#define RTE_Drivers_LL_PINCONF              /* Driver PinPAD and PinMux */
+
+
+#endif /* RTE_COMPONENTS_H */

--- a/hw/bsp/alif/boards/alif_e1c_dk/ae1c1f4051920/rtss_he/board.cmake
+++ b/hw/bsp/alif/boards/alif_e1c_dk/ae1c1f4051920/rtss_he/board.cmake
@@ -1,0 +1,1 @@
+set(MCU_VARIANT M55_HE)

--- a/hw/bsp/alif/boards/alif_e1c_dk/board.cmake
+++ b/hw/bsp/alif/boards/alif_e1c_dk/board.cmake
@@ -6,11 +6,9 @@ set(DSP DSP)
 set(MVE FP_FVE)
 set(BYTE_ORDER Little-endian)
 
-set(SOC_VARIANT AE722F80F55D5)
-set(BOARD_DFP_DIR DevKit-e7)
+set(SOC_VARIANT AE1C1F4051920)
+set(BOARD_DFP_DIR DevKit-e1c)
 set(BOARD_ALIF_DEVKIT_VARIANT 4)
-# Note: E3 (AE302F80F55D5LE) has no native SOC directory in the DFP.
-# E3 targets use this board cmake with E7 SOC includes as a workaround.
 
 # Include qualifiers specific
 include(${CMAKE_CURRENT_LIST_DIR}/${BOARD_QUALIFIERS}/board.cmake)

--- a/hw/bsp/alif/boards/alif_e8_appkit/RTE_Components.h
+++ b/hw/bsp/alif/boards/alif_e8_appkit/RTE_Components.h
@@ -1,0 +1,18 @@
+#ifndef RTE_COMPONENTS_H
+#define RTE_COMPONENTS_H
+
+
+/*
+ * Define the Device Header File:
+ */
+#define CMSIS_device_header "alif.h"
+
+/* AlifSemiconductor::CMSIS Driver:USART@2.1.0 */
+#define RTE_Drivers_USART               /* Driver UART  */
+/* AlifSemiconductor::Device:SOC Peripherals:GPIO@2.1.0 */
+#define RTE_Drivers_IO              /* Driver GPIO */
+/* AlifSemiconductor::Device:SOC Peripherals:PINCONF@2.1.0 */
+#define RTE_Drivers_LL_PINCONF              /* Driver PinPAD and PinMux */
+
+
+#endif /* RTE_COMPONENTS_H */

--- a/hw/bsp/alif/boards/alif_e8_appkit/ae822fa0e5597xx/rtss_he/board.cmake
+++ b/hw/bsp/alif/boards/alif_e8_appkit/ae822fa0e5597xx/rtss_he/board.cmake
@@ -1,0 +1,1 @@
+set(MCU_VARIANT M55_HE)

--- a/hw/bsp/alif/boards/alif_e8_appkit/ae822fa0e5597xx/rtss_hp/board.cmake
+++ b/hw/bsp/alif/boards/alif_e8_appkit/ae822fa0e5597xx/rtss_hp/board.cmake
@@ -1,0 +1,1 @@
+set(MCU_VARIANT M55_HP)

--- a/hw/bsp/alif/boards/alif_e8_appkit/board.cmake
+++ b/hw/bsp/alif/boards/alif_e8_appkit/board.cmake
@@ -6,11 +6,9 @@ set(DSP DSP)
 set(MVE FP_FVE)
 set(BYTE_ORDER Little-endian)
 
-set(SOC_VARIANT AE722F80F55D5)
-set(BOARD_DFP_DIR DevKit-e7)
-set(BOARD_ALIF_DEVKIT_VARIANT 4)
-# Note: E3 (AE302F80F55D5LE) has no native SOC directory in the DFP.
-# E3 targets use this board cmake with E7 SOC includes as a workaround.
+set(SOC_VARIANT AE822FA0E5597)
+set(BOARD_DFP_DIR AppKit-e8)
+set(BOARD_ALIF_DEVKIT_VARIANT 5)
 
 # Include qualifiers specific
 include(${CMAKE_CURRENT_LIST_DIR}/${BOARD_QUALIFIERS}/board.cmake)

--- a/hw/bsp/alif/boards/alif_e8_dk/RTE_Components.h
+++ b/hw/bsp/alif/boards/alif_e8_dk/RTE_Components.h
@@ -1,0 +1,18 @@
+#ifndef RTE_COMPONENTS_H
+#define RTE_COMPONENTS_H
+
+
+/*
+ * Define the Device Header File:
+ */
+#define CMSIS_device_header "alif.h"
+
+/* AlifSemiconductor::CMSIS Driver:USART@2.1.0 */
+#define RTE_Drivers_USART               /* Driver UART  */
+/* AlifSemiconductor::Device:SOC Peripherals:GPIO@2.1.0 */
+#define RTE_Drivers_IO              /* Driver GPIO */
+/* AlifSemiconductor::Device:SOC Peripherals:PINCONF@2.1.0 */
+#define RTE_Drivers_LL_PINCONF              /* Driver PinPAD and PinMux */
+
+
+#endif /* RTE_COMPONENTS_H */

--- a/hw/bsp/alif/boards/alif_e8_dk/ae822fa0e5597xx/rtss_he/board.cmake
+++ b/hw/bsp/alif/boards/alif_e8_dk/ae822fa0e5597xx/rtss_he/board.cmake
@@ -1,0 +1,1 @@
+set(MCU_VARIANT M55_HE)

--- a/hw/bsp/alif/boards/alif_e8_dk/ae822fa0e5597xx/rtss_hp/board.cmake
+++ b/hw/bsp/alif/boards/alif_e8_dk/ae822fa0e5597xx/rtss_hp/board.cmake
@@ -1,0 +1,1 @@
+set(MCU_VARIANT M55_HP)

--- a/hw/bsp/alif/boards/alif_e8_dk/board.cmake
+++ b/hw/bsp/alif/boards/alif_e8_dk/board.cmake
@@ -6,11 +6,9 @@ set(DSP DSP)
 set(MVE FP_FVE)
 set(BYTE_ORDER Little-endian)
 
-set(SOC_VARIANT AE722F80F55D5)
-set(BOARD_DFP_DIR DevKit-e7)
+set(SOC_VARIANT AE822FA0E5597)
+set(BOARD_DFP_DIR DevKit-e8)
 set(BOARD_ALIF_DEVKIT_VARIANT 4)
-# Note: E3 (AE302F80F55D5LE) has no native SOC directory in the DFP.
-# E3 targets use this board cmake with E7 SOC includes as a workaround.
 
 # Include qualifiers specific
 include(${CMAKE_CURRENT_LIST_DIR}/${BOARD_QUALIFIERS}/board.cmake)

--- a/hw/bsp/alif/family.c
+++ b/hw/bsp/alif/family.c
@@ -8,8 +8,16 @@
 #include "Driver_IO.h"
 #include "uart_tracelib.h"
 
-extern ARM_DRIVER_GPIO ARM_Driver_GPIO_(BOARD_LEDRGB1_R_GPIO_PORT);
-static ARM_DRIVER_GPIO* led_port = &ARM_Driver_GPIO_(BOARD_LEDRGB1_R_GPIO_PORT);
+#if BOARD_LEDRGB_COUNT > 1
+#define BOARD_LED_GPIO_PORT  BOARD_LEDRGB1_R_GPIO_PORT
+#define BOARD_LED_GPIO_PIN   BOARD_LEDRGB1_R_GPIO_PIN
+#else
+#define BOARD_LED_GPIO_PORT  BOARD_LEDRGB0_R_GPIO_PORT
+#define BOARD_LED_GPIO_PIN   BOARD_LEDRGB0_R_GPIO_PIN
+#endif
+
+extern ARM_DRIVER_GPIO ARM_Driver_GPIO_(BOARD_LED_GPIO_PORT);
+static ARM_DRIVER_GPIO* led_port = &ARM_Driver_GPIO_(BOARD_LED_GPIO_PORT);
 
 extern ARM_DRIVER_GPIO ARM_Driver_GPIO_(BOARD_JOY_SW_CENTER_GPIO_PORT);
 static ARM_DRIVER_GPIO* button_port = &ARM_Driver_GPIO_(BOARD_JOY_SW_CENTER_GPIO_PORT);
@@ -53,9 +61,9 @@ void board_init(void) {
     }
 
     // Initialize LED
-    led_port->Initialize(BOARD_LEDRGB1_R_GPIO_PIN, NULL);
-    led_port->PowerControl(BOARD_LEDRGB1_R_GPIO_PIN, ARM_POWER_FULL);
-    led_port->SetDirection(BOARD_LEDRGB1_R_GPIO_PIN, GPIO_PIN_DIRECTION_OUTPUT);
+    led_port->Initialize(BOARD_LED_GPIO_PIN, NULL);
+    led_port->PowerControl(BOARD_LED_GPIO_PIN, ARM_POWER_FULL);
+    led_port->SetDirection(BOARD_LED_GPIO_PIN, GPIO_PIN_DIRECTION_OUTPUT);
 
     // Initialize button
     button_port->Initialize(BOARD_JOY_SW_CENTER_GPIO_PIN, NULL);
@@ -83,7 +91,7 @@ void board_init(void) {
  */
 void board_led_write(bool state) {
 #if CFG_TUSB_OS == OPT_OS_NONE || CFG_TUSB_OS == OPT_OS_FREERTOS
-    led_port->SetValue(BOARD_LEDRGB1_R_GPIO_PIN, state ?
+    led_port->SetValue(BOARD_LED_GPIO_PIN, state ?
                     GPIO_PIN_OUTPUT_STATE_HIGH :
                     GPIO_PIN_OUTPUT_STATE_LOW);
 #endif

--- a/hw/bsp/alif/family.cmake
+++ b/hw/bsp/alif/family.cmake
@@ -24,7 +24,14 @@ function(add_board_target BOARD_TARGET)
     return()
   endif ()
 
-  set(LD_SCRIPT ${ALIF_CMSIS_DFP}/Device/core/rtss_hp/linker/linker_gnu_mram.ld.src)
+  # Determine RTSS core directory based on MCU variant
+  if(MCU_VARIANT STREQUAL "M55_HP")
+    set(RTSS_CORE rtss_hp)
+  elseif(MCU_VARIANT STREQUAL "M55_HE")
+    set(RTSS_CORE rtss_he)
+  endif()
+
+  set(LD_SCRIPT ${ALIF_CMSIS_DFP}/Device/core/${RTSS_CORE}/linker/linker_gnu_mram.ld.src)
   message(STATUS "Setting linker source file: ${LD_SCRIPT}")
 
   if (NOT DEFINED STARTUP_FILE_${CMAKE_C_COMPILER_ID})
@@ -75,13 +82,13 @@ function(add_board_target BOARD_TARGET)
   target_include_directories(${BOARD_TARGET} PUBLIC
     ${ALIF_CMSIS_DFP}/Alif_CMSIS/Include
     ${ALIF_CMSIS_DFP}/Alif_CMSIS/Source
-    ${ALIF_CMSIS_DFP}/Device/core/rtss_hp/config
+    ${ALIF_CMSIS_DFP}/Device/core/${RTSS_CORE}/config
     ${ALIF_CMSIS_DFP}/Device/core/common/include
-    ${ALIF_CMSIS_DFP}/Device/soc/AE722F80F55D5/rte
-    ${ALIF_CMSIS_DFP}/Device/soc/AE722F80F55D5/include
-    ${ALIF_CMSIS_DFP}/Device/soc/AE722F80F55D5/include/rtss_hp
+    ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/rte
+    ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/include
+    ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/include/${RTSS_CORE}
     ${ALIF_CMSIS_DFP}/Device/system/include
-    ${ALIF_CMSIS_DFP}/Boards/DevKit-e7
+    ${ALIF_CMSIS_DFP}/Boards/${BOARD_DFP_DIR}
     ${ALIF_CMSIS_DFP}/drivers/include
     ${ALIF_CMSIS_DFP}/libs/board_config
     ${ALIF_CMSIS_DFP}/se_services/include
@@ -93,7 +100,8 @@ function(add_board_target BOARD_TARGET)
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/boards/${BOARD}
     )
 
-  # Add core definitions to board target
+  # Add SOC and core definitions to board target
+  target_compile_definitions(${BOARD_TARGET} PUBLIC ${SOC_VARIANT})
   if(MCU_VARIANT STREQUAL "M55_HP")
     target_compile_definitions(${BOARD_TARGET} PUBLIC CORE_M55_HP)
     target_compile_definitions(${BOARD_TARGET} PUBLIC M55_HP)
@@ -115,8 +123,8 @@ function(add_board_target BOARD_TARGET)
     set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/linker_gnu_mram.ld")
     add_custom_command(TARGET ${BOARD_TARGET} PRE_LINK
        COMMAND ${CMAKE_C_COMPILER} -E -P -mcpu=cortex-m55 -mfloat-abi=hard
-                                   -I ${ALIF_CMSIS_DFP}/Device/soc/AE722F80F55D5/config
-                                   -xc ${LD_SCRIPT} 
+                                   -I ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/config
+                                   -xc ${LD_SCRIPT}
                                    -o ${LD_SCRIPT_PP}
       )
 
@@ -158,28 +166,35 @@ function(configure_freertos)
   set(FREERTOS_HEAP 4 CACHE STRING "FreeRTOS heap implementation")
   set(FREERTOS_CONFIG_FILE_DIRECTORY ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/FreeRTOSConfig CACHE STRING "FreeRTOS configuration file")
 
+  # Determine RTSS core directory based on MCU variant
+  if(MCU_VARIANT STREQUAL "M55_HP")
+    set(RTSS_CORE rtss_hp)
+  elseif(MCU_VARIANT STREQUAL "M55_HE")
+    set(RTSS_CORE rtss_he)
+  endif()
+
   # WORKAROUND: Add the board folder to the include path for the entire directory.
   # The FreeRTOS kernel is built as a separate library and does not automatically
   # inherit the board's include path where RTE_Components.h is located.
   # This ensures the kernel compilation can find the required headers.
   # There is not such problem with latest FreeRTOSKernel but 10.5.1 is not working
   # without setting FREERTOS_CONFIG_FILE_DIRECTORY.
+
   include_directories(
     ${ALIF_CMSIS_DFP}/Alif_CMSIS/Include
     ${ALIF_CMSIS_DFP}/Alif_CMSIS/Source
-    ${ALIF_CMSIS_DFP}/Device/core/rtss_hp/config
+    ${ALIF_CMSIS_DFP}/Device/core/${RTSS_CORE}/config
     ${ALIF_CMSIS_DFP}/Device/core/common/include
-    ${ALIF_CMSIS_DFP}/Device/soc/AE722F80F55D5/rte
-    ${ALIF_CMSIS_DFP}/Device/soc/AE722F80F55D5/include
-    ${ALIF_CMSIS_DFP}/Device/soc/AE722F80F55D5/include/rtss_hp
+    ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/rte
+    ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/include
+    ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/include/${RTSS_CORE}
     ${ALIF_CMSIS_DFP}/Device/system/include
-    ${ALIF_CMSIS_DFP}/Boards/DevKit-e7
+    ${ALIF_CMSIS_DFP}/Boards/${BOARD_DFP_DIR}
     ${ALIF_CMSIS_DFP}/drivers/include
     ${ALIF_CMSIS_DFP}/libs/board_config
     ${ALIF_CMSIS_DFP}/se_services/include
     ${ALIF_CMSIS_DFP}/se_services/port/include
-    ${ALIF_CMSIS_DFP}/se_services/templates    
-    ${ALIF_CMSIS_DFP}/drivers/include
+    ${ALIF_CMSIS_DFP}/se_services/templates
     ${CMSIS_DIR}/CMSIS/Core/Include
     ${CMSIS_DIR}/CMSIS/Driver/Include
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/boards/${BOARD}
@@ -220,7 +235,7 @@ function(family_configure_example TARGET RTOS)
     BOARD_TUD_MAX_SPEED=OPT_MODE_HIGH_SPEED
     CFG_TUSB_MEM_ALIGN=TU_ATTR_ALIGNED\(32\)
     CFG_TUSB_MEM_SECTION=__attribute__\(\(section\(\"usb_dma_buf\"\)\)\)
-    BOARD_ALIF_DEVKIT_VARIANT=4
+    BOARD_ALIF_DEVKIT_VARIANT=${BOARD_ALIF_DEVKIT_VARIANT}
     UNICODE
     _UNICODE
     _DEBUG

--- a/hw/bsp/alif/family.cmake
+++ b/hw/bsp/alif/family.cmake
@@ -1,6 +1,15 @@
-set(ALIF_CMSIS_DFP ${TOP}/hw/mcu/alif/ensemble-cmsis-dfp)
-set(ALIF_COMMON_APP_UTILS ${TOP}/hw/mcu/alif/common-app-utils)
-set(CMSIS_DIR ${TOP}/lib/CMSIS_6)
+if(NOT DEFINED ALIF_CMSIS_DFP)
+  set(ALIF_CMSIS_DFP ${TOP}/hw/mcu/alif/ensemble-cmsis-dfp)
+endif()
+message(STATUS "Using ALIF_CMSIS_DFP: ${ALIF_CMSIS_DFP}")
+if(NOT DEFINED ALIF_COMMON_APP_UTILS)
+  set(ALIF_COMMON_APP_UTILS ${TOP}/hw/mcu/alif/common-app-utils)
+endif()
+message(STATUS "Using ALIF_COMMON_APP_UTILS: ${ALIF_COMMON_APP_UTILS}")
+if(NOT DEFINED CMSIS_DIR)
+  set(CMSIS_DIR ${TOP}/lib/CMSIS_6)
+endif()
+message(STATUS "Using CMSIS_DIR: ${CMSIS_DIR}")
 
 # Include board specific
 include(${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}/board.cmake OPTIONAL RESULT_VARIABLE board_cmake_included)
@@ -84,6 +93,7 @@ function(add_board_target BOARD_TARGET)
     ${ALIF_CMSIS_DFP}/Alif_CMSIS/Source
     ${ALIF_CMSIS_DFP}/Device/core/${RTSS_CORE}/config
     ${ALIF_CMSIS_DFP}/Device/core/common/include
+    ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/config
     ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/rte
     ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/include
     ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/include/${RTSS_CORE}
@@ -185,6 +195,7 @@ function(configure_freertos)
     ${ALIF_CMSIS_DFP}/Alif_CMSIS/Source
     ${ALIF_CMSIS_DFP}/Device/core/${RTSS_CORE}/config
     ${ALIF_CMSIS_DFP}/Device/core/common/include
+    ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/config
     ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/rte
     ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/include
     ${ALIF_CMSIS_DFP}/Device/soc/${SOC_VARIANT}/include/${RTSS_CORE}

--- a/src/portable/alif/alif_e7_dk/dcd_ensemble.c
+++ b/src/portable/alif/alif_e7_dk/dcd_ensemble.c
@@ -201,6 +201,14 @@ static inline void disable_usb_phy_isolation(void) {
     VBAT->PWR_CTRL &= ~VBAT_PWR_CTRL_UPHY_ISO;
 }
 
+static inline void usb_ctrl2_phy_power_on_reset_set(void) {
+    usb_phy_por_set();
+}
+
+static inline void usb_ctrl2_phy_power_on_reset_clear(void) {
+    usb_phy_por_clear();
+}
+
 static inline void _dcd_busy_wait(uint32_t usec) {
     sys_busy_loop_us(usec);
 }


### PR DESCRIPTION
## Changes

### `src/portable/alif/alif_e7_dk/dcd_ensemble.c`

Fix linker errors for CMSIS (bare-metal/FreeRTOS) builds — `usb_ctrl2_phy_power_on_reset_set()` and `usb_ctrl2_phy_power_on_reset_clear()` were only defined in the Zephyr `#if` block. The CMSIS `#else` block was missing equivalents, causing undefined reference linker errors in `dcd_init` and `dcd_deinit`. Added the missing wrappers delegating to `usb_phy_por_set()` / `usb_phy_por_clear()` from DFP 2.1.0's `sys_ctrl_usb.h`.

### `hw/bsp/alif/family.c`

Fix LED GPIO selection for boards with a single RGB LED — `family.c` hardcoded `BOARD_LEDRGB1_*` (second RGB LED), which is not present on AppKit-E8-AIML (`BOARD_LEDRGB_COUNT 1`). Added a `BOARD_LEDRGB_COUNT`-based preprocessor guard to select `LEDRGB0` on single-LED boards and `LEDRGB1` on boards with two or more RGB LEDs (DevKit-E7, DevKit-E8). Behaviour on existing targets is unchanged.
